### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "koa-parse-json": "^1.0.1",
     "koa-router": "^5.3.0",
     "lodash": "^4.0.0",
-    "pg": "^4.4.3",
-    "pg-promise": "^2.9.5",
+    "pg-promise": "^4.0.3",
     "sprintf-js": "^1.0.3",
     "squel": "^4.2.2"
   },


### PR DESCRIPTION
1. a library shouldn't rely an ancient version of pg-promise;
2. with pg-promise one doesn't need to include `pg` dependency (it is available as `pgp.pg`)
